### PR TITLE
Fix NOWPayments check callback

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -528,7 +528,7 @@ def payment_menu(url: str, label: str, lang: str) -> InlineKeyboardMarkup:
 def crypto_invoice_menu(invoice_id: str, lang: str) -> InlineKeyboardMarkup:
     """Return markup for crypto invoice."""
     inline_keyboard = [
-
+        [InlineKeyboardButton('🔄 Check payment', callback_data=f'check_{invoice_id}')],
         [InlineKeyboardButton(t(lang, 'cancel_payment'), callback_data=f'cancel_{invoice_id}')],
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)

--- a/bot/misc/nowpayments.py
+++ b/bot/misc/nowpayments.py
@@ -1,3 +1,4 @@
+import asyncio
 import requests
 from typing import Tuple
 
@@ -31,12 +32,17 @@ def create_payment(amount_eur: float, pay_currency: str) -> Tuple[str, str, floa
     return str(data["payment_id"]), data["pay_address"], float(data["pay_amount"])
 
 
-def check_payment(payment_id: str) -> str | None:
+async def check_payment(payment_id: str) -> str | None:
     """Return payment status string for given payment id."""
+
     headers = {"x-api-key": API_KEY}
-    resp = requests.get(f"{API_BASE}/payment/{payment_id}", headers=headers)
-    if resp.status_code == 404:
-        return None
-    resp.raise_for_status()
-    data = resp.json()
-    return data.get("payment_status")
+
+    def _do_request() -> str | None:
+        resp = requests.get(f"{API_BASE}/payment/{payment_id}", headers=headers)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("payment_status")
+
+    return await asyncio.to_thread(_do_request)


### PR DESCRIPTION
## Summary
- Handle NOWPayments payment status lookup asynchronously to avoid runtime errors when users press "Check payment"

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07a398e08833286c892782dc17331